### PR TITLE
Ignore stateless components in `react/no-multi-comp`

### DIFF
--- a/rules/default.js
+++ b/rules/default.js
@@ -56,7 +56,7 @@ module.exports = {
     "react/no-did-mount-set-state": 2,
     "react/no-did-update-set-state": 2,
     "react/no-direct-mutation-state": 2,
-    "react/no-multi-comp": 2,
+    "react/no-multi-comp": [2, {"ignoreStateless": true}],
     "react/no-unknown-property": 2,
     "react/react-in-jsx-scope": 2,
     "react/self-closing-comp": 2,


### PR DESCRIPTION
This leads to a lot of false positives, like

``` javascript
      <Router
        render={(props) => {
          const { params, routes, location: { query } } = props;
          if (doFetch) {
            app.fetch(routes, app.getState({ params, query }));
          } else {
            doFetch = true;
          }
          return <RouterContext {...props} />;
        }}
      />
```
