### PR TITLE
add more missing rules from LOL

### DIFF
--- a/rules/default.js
+++ b/rules/default.js
@@ -50,6 +50,8 @@ module.exports = {
     "wrap-iife": [2, "inside"],
     "arrow-spacing": 2,
     "comma-spacing": 2,
+    "prefer-spread": 2,
+    "prefer-template": 2,
 
     // react-specific rules
     "react/jsx-boolean-value": 2,


### PR DESCRIPTION
basically:
`Math.max(...args)` is okay, `Math.max.apply(Math, args)` is not
and
`${a}${b}` is okay,  `'a' + 'b'` is not
