### PR TITLE
Replaced deprecated rule 'space-after-keywords' with supported one 'keyword-spacing'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "eslint-plugin-no-loops": "^0.1.1"
   },
   "peerDependencies": {
-    "eslint": ">=1.0.0"
+    "eslint": ">=2.0.0"
   }
 }

--- a/rules/default.js
+++ b/rules/default.js
@@ -44,7 +44,7 @@ module.exports = {
     "no-new-object": 2,
     "no-array-constructor": 2,
     "quote-props": [2, "as-needed"],
-    "space-after-keywords": 2,
+    "keyword-spacing": 2,
     "comma-spacing": 2,
     "space-infix-ops": 2,
     "space-before-function-paren": [2, "never"],


### PR DESCRIPTION
`eslint` complained about this deprecated rule, so I replaced with the new equal rule.
