### PR TITLE
update react plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/buildo/eslint-config",
   "dependencies": {
     "eslint-plugin-no-copy-paste-default-export": "^0.0.3",
-    "eslint-plugin-react": "^3.14.0",
+    "eslint-plugin-react": "^4.1.0",
     "eslint-plugin-no-loops": "^0.1.1"
   },
   "peerDependencies": {

--- a/rules/default.js
+++ b/rules/default.js
@@ -58,7 +58,7 @@ module.exports = {
     "constructor-super": 2,
     "no-const-assign": 2,
     "no-this-before-super": 2,
-    "no-use-before-define": 2,
+    "no-use-before-define": 0, // TODO(gio): enable when this is fixed https://github.com/babel/babel-eslint/issues/249
     "no-var": 2,
     "prefer-const": 2,
     "no-class-assign": 2,
@@ -70,7 +70,7 @@ module.exports = {
 
 
     // React
-    "react/display-name": [2, {"acceptTranspilerName": true}],
+    "react/display-name": [2, {"ignoreTranspilerName": false}],
     "react/jsx-boolean-value": 2,
     "react/jsx-closing-bracket-location": 2,
     "react/jsx-curly-spacing": [2, "never"],


### PR DESCRIPTION
latest eslint-plugin-react and temporarily disable no-use-before-define because of https://github.com/babel/babel-eslint/issues/249

merge after #48 
