### PR TITLE
Revert "#74: max-len should ignore URLs, strings and imports (closes #74)"

### DIFF
--- a/rules/default.js
+++ b/rules/default.js
@@ -39,7 +39,7 @@ module.exports = {
 
     // Stylistic Issues
     "operator-assignment": [2, "never"],
-    "max-len": ["error", 100, { "ignoreTrailingComments": true, "ignoreUrls": true, "ignoreStrings": true, "ignoreTemplateLiterals": true }],
+    "max-len": ["error", 100, { "ignoreTrailingComments": true }],
     "no-plusplus": 2,
     "semi": [2, "always"],
     "no-trailing-spaces": 2,


### PR DESCRIPTION
Reverts buildo/eslint-config#75
