### PR TITLE
#79: rule proposal: promise plugin (closes #79)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "eslint-plugin-no-copy-paste-default-export": "^0.0.3",
     "eslint-plugin-react": "^4.1.0",
-    "eslint-plugin-no-loops": "^0.1.1"
+    "eslint-plugin-no-loops": "^0.1.1",
+    "eslint-plugin-promise": "^3.3.0"
   },
   "peerDependencies": {
     "eslint": ">= 2.4.0 < 4"

--- a/rules/default.js
+++ b/rules/default.js
@@ -8,7 +8,8 @@ module.exports = {
   "plugins": [
     "react",
     "no-copy-paste-default-export",
-    "no-loops"
+    "no-loops",
+    "promise"
   ],
   "ecmaFeatures": {
     "jsx": true,
@@ -76,6 +77,12 @@ module.exports = {
     "prefer-spread": 2,
     "prefer-template": 2,
 
+    // Promise
+    "promise/always-return": 2,
+    "promise/no-return-wrap": 2,
+    "promise/param-names": 2,
+    "promise/catch-or-return": 2,
+    "promise/no-native": 0,
 
     // React
     "react/display-name": [2, {"ignoreTranspilerName": false}],


### PR DESCRIPTION
Issue #79
## Test Plan
### tests performed

I run the _npm lint_ task in _lexdoit_ and the linting works well.

Here are the issues opened for our projects (copied from core issue [215](https://github.com/buildo/core/issues/215#issuecomment-253760754)):
- [x] [buildo-react-components](https://github.com/buildo/react-components/issues/652)
- [x] [lexdoit](https://github.com/buildo/lexdoit/issues/1866)
- [x] [ipercron](https://github.com/buildo/ipercron/issues/243)
- [x] [bobafett](https://github.com/buildo/bobafett/issues/19)
- [ ] [web-shared](https://github.omnilab.our.buildo.io/buildo/web-shared/issues/28)
- [ ] [aliniq](https://github.omnilab.our.buildo.io/buildo/aliniq/issues/4448)
- [ ] [ams](https://github.omnilab.our.buildo.io/buildo/ams/issues/90)
- [ ] ~[oxway](https://github.com/buildo/oxway/issues/620)~ has major `eslint` errors

When all these projects are compliant we can merge this. 
