### PR TITLE
#113: Enfore space before '/>' in self-closing tags (closes #113)

### DIFF
--- a/rules/default.js
+++ b/rules/default.js
@@ -110,6 +110,7 @@ module.exports = {
     'react/react-in-jsx-scope': 2,
     'react/self-closing-comp': 2,
     'react/jsx-wrap-multilines': 2,
+    'react/jsx-tag-spacing': [2, { beforeSelfClosing: 'always' }],
 
     // Warnings
     // things that could be ok in dev but not in prod


### PR DESCRIPTION
Closes #113

## Test Plan

### tests performed

1. Added the same rule to the linto-config.yml file:
```diff
@@ -76,3 +76,4 @@ eslintConfig:
   extends: buildo
   rules:
     max-len: 0
+    react/jsx-tag-spacing: [2, { beforeSelfClosing: 'always' }]
```

2. Run linto check and fixed all problems. All the corresponding PRs have been merged;
3. Run another linto test, results are the following:
![image](https://cloud.githubusercontent.com/assets/6418684/25960409/2685ba12-3677-11e7-858e-d006c17e8890.png)


### tests not performed (domain coverage)
Still have to run linto report
